### PR TITLE
New cluster checking logic

### DIFF
--- a/src/server/Bundler.cs
+++ b/src/server/Bundler.cs
@@ -1,44 +1,34 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
+using LogicWorld.Server.Circuitry;
 using LogicAPI.Server.Components;
+
+using WireBundle.Server;
 
 namespace WireBundle.Components
 {
     public class Bundler : LogicComponent
     {
-        private readonly List<Splitter> linkedSplitters = new List<Splitter>();
+        protected override void Initialize()
+        {
+            Bundlers.Components.Add(((OutputPeg)this.Outputs[0]).oAddress, this);
+        }
 
         public override void OnComponentDestroyed()
         {
-            foreach (Splitter linkedSplitter in linkedSplitters)
-            {
-                linkedSplitter.bundlerDestroyed();
-            }
-            linkedSplitters.Clear();
+            Bundlers.Components.Remove(((OutputPeg)this.Outputs[0]).oAddress);
         }
 
         protected override void DoLogicUpdate()
         {
-            //TODO: This will unfortunately always be 1 tick delayed. Make it instant regardless. If technically even possible... Probably would need a hidden peg. Or make this output a peg.
             bool active = false;
-            for (int i = 0; i < Inputs.Count; i++)
+            for (int i = 0; i < base.Inputs.Count; i++)
             {
-                if (Inputs[i].On)
-                {
-                    active = true;
-                }
+                if (base.Inputs[i].On) { active = true; }
             }
-            Outputs[0].On = active;
-        }
-
-        public void unregisterSplitter(Splitter splitter)
-        {
-            linkedSplitters.Remove(splitter);
-        }
-
-        public void registerSplitter(Splitter splitter)
-        {
-            linkedSplitters.Add(splitter);
+            base.Outputs[0].On = active;
         }
     }
 }

--- a/src/server/WireBundleServer.cs
+++ b/src/server/WireBundleServer.cs
@@ -1,4 +1,16 @@
+using System.Collections.Generic;
+
+using LogicWorld.Server.Circuitry;
+using LogicAPI.Server.Components;
 using LogicAPI.Server;
+using LogicAPI.Data;
+using LogicLog;
+using LogicWorld.LogicCode;
+
+
+using WireBundle.Components;
+
+using LICC;
 
 namespace WireBundle.Server
 {
@@ -8,5 +20,10 @@ namespace WireBundle.Server
         {
             Logger.Info("WireBundle mod is ready to bundle up some wires!");
         }
+    }
+
+    public static class Bundlers
+    {
+        public static Dictionary<OutputAddress, Bundler> Components = new Dictionary<OutputAddress, Bundler>();
     }
 }


### PR DESCRIPTION
This update makes it so that the splitter checks the cluster it is in and all the linked clusters for bunders, and when a bundler is added/removed from the network, it connects/disconnects the blunder and the splitter